### PR TITLE
Don't ping reply, and delete on some edits

### DIFF
--- a/src/onMessageUpdate.civet
+++ b/src/onMessageUpdate.civet
@@ -9,6 +9,7 @@ export onMessageUpdate := (session: Session, message: GatewayEvents['MESSAGE_UPD
   return unless messageBotId
   unless body
     await deleteMessage session, message.channel_id, messageBotId
+    session.messagesCache.delete message.id
     return
   return unless files
   await editMessage session, message.channel_id, messageBotId, {...body, attachments: []}, files

--- a/src/onMessageUpdate.civet
+++ b/src/onMessageUpdate.civet
@@ -1,4 +1,4 @@
-{ editMessage, getRequestBody } from ./utils.civet
+{ deleteMessage, editMessage, getRequestBody } from ./utils.civet
 type { GatewayEvents } from @biscuitland/ws
 type { Session } from @biscuitland/core
 
@@ -7,5 +7,8 @@ export onMessageUpdate := (session: Session, message: GatewayEvents['MESSAGE_UPD
   { body, files } := await getRequestBody message
   messageBotId := session.messagesCache.get message.id
   return unless messageBotId
+  unless body
+    await deleteMessage session, message.channel_id, messageBotId
+    return
   return unless files
   await editMessage session, message.channel_id, messageBotId, {...body, attachments: []}, files

--- a/src/utils.civet
+++ b/src/utils.civet
@@ -12,6 +12,9 @@ sendMessage := (session: Session, id: string, body?: RESTPostAPIChannelMessageJS
 editMessage := (session: Session, channelId: string, id: string, body?: RESTPostAPIChannelMessageJSONBody, files?: RawFile[]) ->
   session.api.channels channelId |> .messages id |> .patch body: body, files: files
 
+deleteMessage := (session: Session, channelId: string, id: string) ->
+  session.api.channels channelId |> .messages id |> .delete()
+
 getRequestBody := async (message: GatewayEvents['MESSAGE_CREATE'] | GatewayEvents['MESSAGE_UPDATE']) ->
   unless message.content
     return
@@ -34,6 +37,8 @@ getRequestBody := async (message: GatewayEvents['MESSAGE_CREATE'] | GatewayEvent
       channel_id: message.channel_id,
       guild_id: message.guild_id,
       fail_if_not_exists: false
+    allowed_mentions:
+      replied_user: false
 
   if transpiledCodes.reduce (acc, val) => acc + val.length + 8, 0 |> & + `↓↓↓ **${version}**`.length > 1500
     files.push ...transpiledCodes[0...10].map ($, i) -> data: createSnippet($, false), name: `result${i}.ts`
@@ -76,4 +81,4 @@ compileCode := (civetCode: string, usePrettier: boolean, js: boolean, coffee: bo
 
   prettierInfo + tsCode
 
-export editMessage, sendMessage, compileCode, getRequestBody
+export editMessage, sendMessage, compileCode, getRequestBody, deleteMessage


### PR DESCRIPTION
This PR contains two unrelated but small changes:
- The bot's reply no longer pings the OP. It's still linked to the original message, but it no longer sends a notification or highlights the message yellow.
- If the code block is changed from `civet`/`coffee`/etc to another language that the bot can't transpile, its response is deleted.
  - I didn't also make the bot delete its response if the original message is entirely deleted, but I could do that, too.